### PR TITLE
Add env-aware balance checking script

### DIFF
--- a/scripts/check-balance.js
+++ b/scripts/check-balance.js
@@ -1,0 +1,30 @@
+require('dotenv').config();
+const { ethers } = require('hardhat');
+
+async function main() {
+  const contractAddress = process.env.CONTRACT_ADDRESS && process.env.CONTRACT_ADDRESS.trim();
+  if (!contractAddress) {
+    throw new Error('CONTRACT_ADDRESS environment variable is required to check token balances.');
+  }
+
+  const [deployer] = await ethers.getSigners();
+  console.log(`Deployer address: ${deployer.address}`);
+  console.log(`Token contract address: ${contractAddress}`);
+
+  const token = await ethers.getContractAt('MockToken', contractAddress);
+
+  const [totalSupply, deployerTokenBalance, deployerEthBalance] = await Promise.all([
+    token.totalSupply(),
+    token.balanceOf(deployer.address),
+    deployer.getBalance(),
+  ]);
+
+  console.log(`Total supply: ${ethers.utils.formatEther(totalSupply)} MOCK`);
+  console.log(`Deployer token balance: ${ethers.utils.formatEther(deployerTokenBalance)} MOCK`);
+  console.log(`Deployer ETH balance: ${ethers.utils.formatEther(deployerEthBalance)} ETH`);
+}
+
+main().catch((error) => {
+  console.error('Failed to check balances:', error.message || error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- load environment variables for the balance script and validate CONTRACT_ADDRESS
- instantiate the deployed MockToken and report total supply and deployer token balance
- include deployer ETH balance output for additional context

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfb2148c8c832098ffce6c801e56b7